### PR TITLE
Force set proc-macro2 to newest to fix unknown feature

### DIFF
--- a/rust_utilities/Cargo.lock
+++ b/rust_utilities/Cargo.lock
@@ -86,9 +86,9 @@ checksum = "6f61fba1741ea2b3d6a1e3178721804bb716a68a6aeba1149b5d52e3d464ea66"
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.51"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d727cae5b39d21da60fa540906919ad737832fe0b1c165da3a34d6548c849d6"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -108,6 +108,7 @@ version = "0.1.0"
 dependencies = [
  "flate2",
  "once_cell",
+ "proc-macro2",
  "wasm_guardian",
  "xxhash-rust",
 ]

--- a/rust_utilities/Cargo.toml
+++ b/rust_utilities/Cargo.toml
@@ -7,15 +7,16 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-wasm_guardian = {path = "../wasm_guardian"}
+wasm_guardian = { path = "../wasm_guardian" }
 flate2 = "1.0.25"
-xxhash-rust = {version = "0.8.5", features = ["xxh3"]}
+xxhash-rust = { version = "0.8.5", features = ["xxh3"] }
 once_cell = "1.17.0"
+proc-macro2 = "1.0.86"
 
 [profile.release]
- # Consider these options for a smaller binary size
- strip = true
- panic = "abort"
- opt-level = "z"  # Optimize for size.
- lto = true
- codegen-units = 1
+# Consider these options for a smaller binary size
+strip = true
+panic = "abort"
+opt-level = "z"   # Optimize for size.
+lto = true
+codegen-units = 1


### PR DESCRIPTION
This resolves the following error when attempting building on newer versions of the Rust toolchain:

```
error[E0635]: unknown feature `proc_macro_span_shrink`
  --> ~/.cargo/registry/src/index.crates.io-6f17d22bba15001f/proc-macro2-1.0.51/src/lib.rs:92:30
   |
92 |     feature(proc_macro_span, proc_macro_span_shrink)
   |                              ^^^^^^^^^^^^^^^^^^^^^^
```